### PR TITLE
Add credentials support for Cosmos DB

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -466,7 +466,7 @@ dotnet_diagnostic.SA1633.severity = none            # https://github.com/atc-net
 # https://rules.sonarsource.com/csharp
 dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
 dotnet_diagnostic.S3267.severity = none             # https://rules.sonarsource.com/csharp/RSPEC-3267 -> pointless rule.
-
+dotnet_diagnostic.S3358.severity = none             # https://rules.sonarsource.com/csharp/RSPEC-3358 -> Ternary operators should not be nested
 
 ##########################################
 # Custom - Code Analyzers Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   Test
+-   Support for Token Credentials with Comos DB using `UseCredentials` methods on options class.
+
+### Deprecated
+
+-   EventStore `ConnectionString` option has been made obsolete, please use `UseCredentials` or `UseCosmosEmulator` instead.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,9 +39,9 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.2.1" PrivateAssets="all" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
+++ b/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosClientFactory.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosClientFactory.cs
@@ -14,9 +14,21 @@ namespace Atc.Cosmos.EventStore.Cosmos
             CosmosEventSerializer eventSerializer)
         {
             options.Value.CosmosClientOptions.Serializer = eventSerializer;
-            cosmosClient = new CosmosClient(
-                options.Value.ConnectionString,
-                options.Value.CosmosClientOptions);
+#pragma warning disable CS0618 // Type or member is obsolete
+            cosmosClient = options.Value.Credential is null
+                ? options.Value.ConnectionString is not null
+                    ? new CosmosClient(
+                        options.Value.ConnectionString,
+                        options.Value.CosmosClientOptions)
+                    : new CosmosClient(
+                        options.Value.Endpoint,
+                        options.Value.AuthKey,
+                        options.Value.CosmosClientOptions)
+                : new CosmosClient(
+                    options.Value.Endpoint,
+                    options.Value.Credential,
+                    options.Value.CosmosClientOptions);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public CosmosClient GetClient()

--- a/src/Atc.Cosmos.EventStore/EventStoreClientOptions.cs
+++ b/src/Atc.Cosmos.EventStore/EventStoreClientOptions.cs
@@ -1,12 +1,37 @@
+using System;
+using Azure.Core;
 using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos.EventStore
 {
     public class EventStoreClientOptions
     {
+        public const string EmulatorEndpoint = "https://localhost:8081/";
+        public const string EmulatorAuthKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+        [Obsolete("Call UseCosmosEmulator instead.")]
         public const string CosmosEmulatorConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
-        public string ConnectionString { get; set; } = CosmosEmulatorConnectionString;
+#pragma warning disable CS0618 // Type or member is obsolete
+        private string? connectionString = CosmosEmulatorConnectionString;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        [Obsolete("Call UseCredentals instead.")]
+        public string? ConnectionString
+        {
+            get
+            {
+                return connectionString;
+            }
+
+            set
+            {
+                connectionString = value;
+                AuthKey = null;
+                Endpoint = null;
+                Credential = null;
+            }
+        }
 
         public string EventStoreDatabaseId { get; set; } = "EventStore";
 
@@ -17,5 +42,45 @@ namespace Atc.Cosmos.EventStore
         public string SubscriptionContainerId { get; set; } = "subscriptions";
 
         public CosmosClientOptions CosmosClientOptions { get; set; } = new CosmosClientOptions();
+
+        public string? Endpoint { get; private set; }
+
+        public string? AuthKey { get; private set; }
+
+        public TokenCredential? Credential { get; private set; }
+
+        public void UseCredentials(
+            string endpoint,
+            TokenCredential credentials)
+        {
+            Credential = credentials ?? throw new ArgumentNullException(nameof(credentials));
+            Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            AuthKey = null;
+#pragma warning disable CS0618 // Type or member is obsolete
+            ConnectionString = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        public void UseCredentials(
+            string endpoint,
+            string authKey)
+        {
+            Credential = null;
+            Endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            AuthKey = authKey ?? throw new ArgumentNullException(nameof(authKey));
+#pragma warning disable CS0618 // Type or member is obsolete
+            ConnectionString = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        public void UseCosmosEmulator()
+        {
+            Credential = null;
+            Endpoint = EmulatorEndpoint;
+            AuthKey = EmulatorAuthKey;
+#pragma warning disable CS0618 // Type or member is obsolete
+            ConnectionString = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a set of overloads for setting credentials using `EventStoreClientOptions`.

`ConnectionString` property has been made obsolete and one of the following methods should be used instead.
``` charp
 UseCredentials(endpoint, authkey)
 UseCredentials(endpoint, TokenCredentials)
 UseCosmosEmulator()
```

> The options will still default to Cosmos Emulator.