### PR TITLE
Feature/exlude metadata from iterator

### DIFF
--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosEventStoreInitializer.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosEventStoreInitializer.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
@@ -62,6 +63,13 @@ namespace Atc.Cosmos.EventStore.Cosmos
 
             // Exclude event data from indexing.
             containerOptions.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = "/data/*" });
+
+            containerOptions.IndexingPolicy.CompositeIndexes.Add(new(
+                new[]
+                {
+                    new CompositePath { Path = "/pk", Order = CompositePathSortOrder.Ascending },
+                    new CompositePath { Path = "/properties/version", Order = CompositePathSortOrder.Ascending },
+                }.ToList()));
 
             return clientFactory
                 .GetClient()

--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosStreamIterator.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosStreamIterator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Atc.Cosmos.EventStore.Events;
@@ -34,7 +35,7 @@ namespace Atc.Cosmos.EventStore.Cosmos
                     .ReadNextAsync(cancellationToken)
                     .ConfigureAwait(false);
 
-                foreach (var item in items.Resource)
+                foreach (var item in items.Resource.Where(d => d is not null))
                 {
                     yield return item;
                 }

--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosStreamQueryBuilder.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosStreamQueryBuilder.cs
@@ -14,7 +14,7 @@ namespace Atc.Cosmos.EventStore.Cosmos
         {
             var parameters = new Dictionary<string, object>();
             var query = new StringBuilder();
-            query.Append("SELECT * FROM events e WHERE e.pk = @partitionKey ");
+            query.Append("SELECT * FROM e WHERE e.pk = @partitionKey ");
             parameters["@partitionKey"] = streamId.Value;
 
             if (fromVersion != StreamVersion.Any && fromVersion != StreamVersion.NotEmpty)

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Atc.Test" Version="1.0.45" />
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
+++ b/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Atc.Test" Version="1.0.45" />
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Atc.Test" Version="1.0.45" />
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Atc.Cosmos.EventStore.Tests/Cosmos/CosmosStreamIteratorTests.cs
+++ b/test/Atc.Cosmos.EventStore.Tests/Cosmos/CosmosStreamIteratorTests.cs
@@ -107,7 +107,7 @@ namespace Atc.Cosmos.EventStore.Tests.Cosmos
             query
                 .QueryText
                 .Should()
-                .Be("SELECT * FROM events e WHERE e.pk = @partitionKey ORDER BY e.properties.version");
+                .Be("SELECT * FROM e WHERE e.pk = @partitionKey ORDER BY e.properties.version");
             query
                 .GetQueryParameters()
                 .Should()
@@ -128,7 +128,7 @@ namespace Atc.Cosmos.EventStore.Tests.Cosmos
             query
                 .QueryText
                 .Should()
-                .Be("SELECT * FROM events e WHERE e.pk = @partitionKey AND e.properties.version >= @fromVersion ORDER BY e.properties.version");
+                .Be("SELECT * FROM e WHERE e.pk = @partitionKey AND e.properties.version >= @fromVersion ORDER BY e.properties.version");
             query
                 .GetQueryParameters()
                 .Should()
@@ -157,7 +157,7 @@ namespace Atc.Cosmos.EventStore.Tests.Cosmos
             query
                 .QueryText
                 .Should()
-                .Be("SELECT * FROM events e WHERE e.pk = @partitionKey AND e.properties.version >= @fromVersion AND (e.properties.name = @name1) ORDER BY e.properties.version");
+                .Be("SELECT * FROM e WHERE e.pk = @partitionKey AND e.properties.version >= @fromVersion AND (e.properties.name = @name1) ORDER BY e.properties.version");
             query
                 .GetQueryParameters()
                 .Should()
@@ -190,7 +190,7 @@ namespace Atc.Cosmos.EventStore.Tests.Cosmos
             query
                 .QueryText
                 .Should()
-                .Be("SELECT * FROM events e WHERE e.pk = @partitionKey AND e.properties.version >= @fromVersion AND (e.properties.name = @name1 OR e.properties.name = @name2 OR e.properties.name = @name3) ORDER BY e.properties.version");
+                .Be("SELECT * FROM e WHERE e.pk = @partitionKey AND e.properties.version >= @fromVersion AND (e.properties.name = @name1 OR e.properties.name = @name2 OR e.properties.name = @name3) ORDER BY e.properties.version");
             query
                 .GetQueryParameters()
                 .Should()


### PR DESCRIPTION
This PR introduces a composite index when querying events from a stream. Included are also a hotfix for handling null document returned when the `EventConverter` encounters the metadata document.