### PR TITLE
Feature/removed dependency to add initializer

### DIFF
--- a/Atc.Cosmos.EventStore.sln
+++ b/Atc.Cosmos.EventStore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29827.131
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32120.378
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Cosmos.EventStore", "src\Atc.Cosmos.EventStore\Atc.Cosmos.EventStore.csproj", "{1313EC2E-D1E1-42EC-8D68-912BB8492B4B}"
 EndProject
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Cosmos.EventStore.Tests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".docs", ".docs", "{896CBC7A-D026-473B-8AFB-843FACB98624}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		docs\Concepts.md = docs\Concepts.md
 	EndProjectSection
 EndProject

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/EventStoreCqrsBuilder.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/EventStoreCqrsBuilder.cs
@@ -10,6 +10,7 @@ using Atc.Cosmos.EventStore.Cqrs.Projections;
 using Atc.Cosmos.EventStore.DependencyInjection;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
 {
@@ -68,6 +69,8 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
             builder.Services.AddHostedService<ProjectionJob<TProjection>>();
             builder.Services.AddSingleton<IProjectionProcessor<TProjection>, ProjectionProcessor<TProjection>>();
             builder.Services.AddTransient<TProjection>();
+            builder.Services.TryAddSingleton<IDependencyInitializer>(
+                new DependencyInitializer(() => Task.CompletedTask));
 
             var projectionBuilder = new ProjectionBuilder(name);
 
@@ -88,6 +91,7 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
             int throughput,
             Func<IServiceProvider, Task>? additionInitialization = null)
         {
+            builder.Services.RemoveAll<IDependencyInitializer>();
             builder.Services.AddSingleton<IDependencyInitializer>(s =>
                 new DependencyInitializer(
                     async () =>

--- a/src/Atc.Cosmos.EventStore.Cqrs/Internal/DependencyInitializer.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Internal/DependencyInitializer.cs
@@ -9,9 +9,7 @@ namespace Atc.Cosmos.EventStore.Cqrs.Internal
 
         public DependencyInitializer(
             Func<Task> task)
-        {
-            initializer = task();
-        }
+            => initializer = task();
 
         public Task EnsureInitializeAsync()
             => initializer;

--- a/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
+++ b/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Cosmos.EventStore/EventStoreClientOptions.cs
+++ b/src/Atc.Cosmos.EventStore/EventStoreClientOptions.cs
@@ -16,7 +16,7 @@ namespace Atc.Cosmos.EventStore
         private string? connectionString = CosmosEmulatorConnectionString;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        [Obsolete("Call UseCredentals instead.")]
+        [Obsolete("Call UseCredentials instead.")]
         public string? ConnectionString
         {
             get
@@ -49,6 +49,12 @@ namespace Atc.Cosmos.EventStore
 
         public TokenCredential? Credential { get; private set; }
 
+        /// <summary>
+        /// Configure event store to use <seealso cref="TokenCredential"/> instead <see cref="AuthKey"/>.
+        /// </summary>
+        /// <param name="endpoint">Cosmos account endpoint.</param>
+        /// <param name="credentials">Token credentials to use when connecting to cosmos.</param>
+        /// <exception cref="ArgumentNullException">Throws when <paramref name="credentials"/> or <paramref name="endpoint"/> are null.</exception>
         public void UseCredentials(
             string endpoint,
             TokenCredential credentials)
@@ -61,6 +67,12 @@ namespace Atc.Cosmos.EventStore
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        /// <summary>
+        /// Configure event storte to use AuthKey when connecting to cosmos db.
+        /// </summary>
+        /// <param name="endpoint">Cosmos account endpoint.</param>
+        /// <param name="authKey">Authorization key to connect with.</param>
+        /// <exception cref="ArgumentNullException">Throws when <paramref name="authKey"/> or <paramref name="endpoint"/> are null.</exception>
         public void UseCredentials(
             string endpoint,
             string authKey)
@@ -73,6 +85,9 @@ namespace Atc.Cosmos.EventStore
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        /// <summary>
+        /// Configure event store to use cosmos emulator.
+        /// </summary>
         public void UseCosmosEmulator()
         {
             Credential = null;


### PR DESCRIPTION
This PR addresses the issue where a projection is configured but `AddInitializer" is not used, resulting in a DI exception.

Exception received:
`Exception Info: System.InvalidOperationException: Unable to resolve service for type 'Atc.Cosmos.EventStore.Cqrs.Internal.IDependencyInitializer' while attempting to activate`.
