### PR TITLE
Feature/introduce subscription exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.lutconfig
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Atc.Cosmos.EventStore.sln
+++ b/Atc.Cosmos.EventStore.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".docs", ".docs", "{896CBC7A
 	ProjectSection(SolutionItems) = preProject
 		CHANGELOG.md = CHANGELOG.md
 		docs\Concepts.md = docs\Concepts.md
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Cosmos.EventStore.Cqrs", "src\Atc.Cosmos.EventStore.Cqrs\Atc.Cosmos.EventStore.Cqrs.csproj", "{B7ABF0D8-940D-4392-B619-ECFBA0A58EE6}"
@@ -18,6 +19,27 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Cosmos.EventStore.IntegrationTests", "test\Atc.Cosmos.EventStore.IntegrationTests\Atc.Cosmos.EventStore.IntegrationTests.csproj", "{55C3F01F-5A47-4821-82EB-9F5F3FCC669F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Cosmos.EventStore.Cqrs.Tests", "test\Atc.Cosmos.EventStore.Cqrs.Tests\Atc.Cosmos.EventStore.Cqrs.Tests.csproj", "{04D95696-E998-4BB4-9C97-2B272FB2115B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9F8C68FA-328D-4417-9797-A4B43415F4B1}"
+	ProjectSection(SolutionItems) = preProject
+		src\.editorconfig = src\.editorconfig
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{249A7550-9083-410E-9188-E00F981F8D44}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+		test\Directory.Build.props = test\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{F6956D27-E4B8-46EE-AA7F-4DB289A18F57}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		Directory.Build.props = Directory.Build.props
+		global.json = global.json
+		version.json = version.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,6 +70,13 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1313EC2E-D1E1-42EC-8D68-912BB8492B4B} = {9F8C68FA-328D-4417-9797-A4B43415F4B1}
+		{2A182C87-5FD5-4318-9339-94F36ED800FB} = {249A7550-9083-410E-9188-E00F981F8D44}
+		{B7ABF0D8-940D-4392-B619-ECFBA0A58EE6} = {9F8C68FA-328D-4417-9797-A4B43415F4B1}
+		{55C3F01F-5A47-4821-82EB-9F5F3FCC669F} = {249A7550-9083-410E-9188-E00F981F8D44}
+		{04D95696-E998-4BB4-9C97-2B272FB2115B} = {249A7550-9083-410E-9188-E00F981F8D44}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DB70B849-5672-4B7A-9545-EAC03E0484D1}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Exception delegate for receiving any exception douing a stream subscription.
+- Throws `ArgumentException` when a projection is missing a `ProjectionFilter`.
+- **BREAKING** - `IProjection` now require you to implement `FailedAsync(Exception exception,
+  CancellationToken cancellationToken)` and instruct the framework on how to proceed when encountering an exception.
+- Convenience extension methods to CommandContext.
+
 ## [1.5.3] - 2022-07-05
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,9 +39,9 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.0" PrivateAssets="all" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.41.0.50478" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Cosmos.EventStore.Cqrs/CommandContextExtensions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/CommandContextExtensions.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Atc.Cosmos.EventStore.Cqrs
+{
+    public static class CommandContextExtensions
+    {
+        public static ICommandContext AddEventWhen(
+            this ICommandContext context,
+            Func<bool> condition,
+            Func<object> eventProvider)
+            => condition()
+             ? context.OnAddEvent(eventProvider())
+             : context;
+
+        public static ValueTask AsAsync(
+            this ICommandContext context)
+            => default; // default is a completed value task.
+
+        private static ICommandContext OnAddEvent(
+            this ICommandContext context,
+            object @event)
+        {
+            context.AddEvent(@event);
+
+            return context;
+        }
+    }
+}

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/EventStoreCqrsBuilder.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/EventStoreCqrsBuilder.cs
@@ -18,10 +18,9 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
     {
         private readonly EventStoreOptionsBuilder builder;
 
-        public EventStoreCqrsBuilder(EventStoreOptionsBuilder builder)
-        {
-            this.builder = builder;
-        }
+        public EventStoreCqrsBuilder(
+            EventStoreOptionsBuilder builder)
+            => this.builder = builder;
 
         public IEventStoreCqrsBuilder AddCommandsFromAssembly<TAssembly>()
         {
@@ -33,10 +32,10 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
                     .GetInterfaces()
                     .Where(i => i.IsGenericType && i.GetGenericTypeDefinition().Equals(typeof(ICommandHandler<>)))
                     .Select(i => new
-                    {
-                        CommandHandlerType = t,
-                        CommandType = i.GetGenericArguments()[0],
-                    }))
+                        {
+                            CommandHandlerType = t,
+                            CommandType = i.GetGenericArguments()[0],
+                        }))
                 .Select(t => typeof(EventStoreCqrsBuilder)
                     .GetRuntimeMethods()
                     .First(m => m.Name.Equals(nameof(AddCommand), StringComparison.OrdinalIgnoreCase))
@@ -76,13 +75,11 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
 
             configure?.Invoke(projectionBuilder);
 
-            SetFiltersFromProjection<TProjection>(projectionBuilder);
-
             builder
                 .Services
                 .Configure<ProjectionOptions>(
                     typeof(TProjection).Name,
-                    options => projectionBuilder.Build(options));
+                    options => projectionBuilder.Build<TProjection>(options));
 
             return this;
         }
@@ -113,13 +110,5 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
 
             return this;
         }
-
-        private static void SetFiltersFromProjection<T>(ProjectionBuilder builder)
-            => Array.ForEach(
-                typeof(T)
-                    .GetCustomAttributes<ProjectionFilterAttribute>()
-                    .Select(a => a.Filter)
-                    .ToArray(),
-                f => builder.WithFilter(f));
     }
 }

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/ProjectionBuilder.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/ProjectionBuilder.cs
@@ -6,20 +6,20 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
 {
     internal class ProjectionBuilder : IProjectionBuilder
     {
-        private readonly List<StreamFilter> filters;
+        private readonly List<ProjectionFilter> filters;
         private ProcessExceptionHandler exceptionHandler;
         private string name;
 
         public ProjectionBuilder(string name)
         {
             this.name = name;
-            filters = new List<StreamFilter>();
+            filters = new List<ProjectionFilter>();
             exceptionHandler = ProjectionOptions.EmptyExceptionHandler;
         }
 
         public IProjectionBuilder WithFilter(string filter)
         {
-            filters.Add(new StreamFilter(filter));
+            filters.Add(new ProjectionFilter(filter));
 
             return this;
         }

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/ProjectionBuilder.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/Internal/ProjectionBuilder.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Atc.Cosmos.EventStore.Cqrs.Projections;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -38,11 +41,27 @@ namespace Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal
             return this;
         }
 
-        public void Build(ProjectionOptions options)
+        public void Build<TProjection>(ProjectionOptions options)
+            where TProjection : class, IProjection
         {
+            SetFiltersFromProjection<TProjection>();
+            if (filters.Count == 0)
+            {
+                throw new ArgumentException(
+                    $"Please provide a filter for type {typeof(TProjection)}");
+            }
+
             options.Name = name;
             options.Filters = filters;
             options.ExceptionHandler = exceptionHandler;
         }
+
+        private void SetFiltersFromProjection<T>()
+               => Array.ForEach(
+                   typeof(T)
+                       .GetCustomAttributes<ProjectionFilterAttribute>()
+                       .Select(a => a.Filter)
+                       .ToArray(),
+                   f => WithFilter(f));
     }
 }

--- a/src/Atc.Cosmos.EventStore.Cqrs/IProjection.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/IProjection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -5,6 +6,10 @@ namespace Atc.Cosmos.EventStore.Cqrs
 {
     public interface IProjection
     {
+        Task<ProjectionAction> FailedAsync(
+            Exception exception,
+            CancellationToken cancellationToken);
+
         Task InitializeAsync(
             EventStreamId id,
             CancellationToken cancellationToken);

--- a/src/Atc.Cosmos.EventStore.Cqrs/ProjectionAction.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/ProjectionAction.cs
@@ -1,0 +1,8 @@
+﻿namespace Atc.Cosmos.EventStore.Cqrs
+{
+    public enum ProjectionAction
+    {
+        Continue = 0,
+        Stop,
+    }
+}

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/IProjectionJob.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/IProjectionJob.cs
@@ -1,8 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Atc.Cosmos.EventStore.Cqrs.Projections
 {
+    [SuppressMessage(
+        "Major Code Smell",
+        "S2326:Unused type parameters should be removed",
+        Justification = "Interface is used with DI to distinguish one projection from another")]
     internal interface IProjectionJob<TProjection>
         where TProjection : IProjection
     {

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/IProjectionOptions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/IProjectionOptions.cs
@@ -6,7 +6,7 @@ namespace Atc.Cosmos.EventStore.Cqrs.Projections
     {
         string Name { get; }
 
-        IReadOnlyCollection<StreamFilter> Filters { get; }
+        IReadOnlyCollection<ProjectionFilter> Filters { get; }
 
         ProcessExceptionHandler ExceptionHandler { get; }
     }

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/IProjectionProcessor.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/IProjectionProcessor.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Atc.Cosmos.EventStore.Cqrs.Projections
 {
+    [SuppressMessage(
+        "Major Code Smell",
+        "S2326:Unused type parameters should be removed",
+        Justification = "Interface is used with DI to distinguish one projection processor from another")]
     internal interface IProjectionProcessor<TProjection>
         where TProjection : IProjection
     {
-        Task ProcessBatchAsync(
+        Task<ProjectionAction> ProcessBatchAsync(
             IEnumerable<IEvent> batch,
             CancellationToken cancellationToken);
     }

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionFilter.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionFilter.cs
@@ -4,12 +4,12 @@ using System.Linq;
 
 namespace Atc.Cosmos.EventStore.Cqrs.Projections
 {
-    internal class StreamFilter
+    internal class ProjectionFilter
     {
         private readonly IReadOnlyList<Func<string, bool>> validators;
         private readonly bool endsOnAcceptAll;
 
-        public StreamFilter(string filter)
+        public ProjectionFilter(string filter)
         {
             validators = filter
                 .Split(

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionJob.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionJob.cs
@@ -46,12 +46,22 @@ namespace Atc.Cosmos.EventStore.Cqrs.Projections
         public Task StopAsync(CancellationToken cancellationToken)
             => subscription.StopAsync();
 
-        private Task OnProcessEventsAsync(
+        private async Task OnProcessEventsAsync(
             IEnumerable<IEvent> events,
             CancellationToken cancellationToken)
-            => processor
+        {
+            var action = await processor
                 .ProcessBatchAsync(
                     events,
-                    cancellationToken);
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (action == ProjectionAction.Stop)
+            {
+                await subscription
+                    .StopAsync()
+                    .ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionJob.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionJob.cs
@@ -28,7 +28,8 @@ namespace Atc.Cosmos.EventStore.Cqrs.Projections
             subscription = client.SubscribeToStreams(
                 ConsumerGroup.GetAsAutoScalingInstance(options.Name),
                 SubscriptionStartOptions.FromBegining,
-                OnProcessEventsAsync);
+                OnProcessEventsAsync,
+                options.ExceptionHandler);
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionOptions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionOptions.cs
@@ -7,18 +7,18 @@ namespace Atc.Cosmos.EventStore.Cqrs.Projections
     internal class ProjectionOptions : IProjectionOptions
     {
         public static readonly ProcessExceptionHandler EmptyExceptionHandler = (e, ct)
-            => new ValueTask(Task.CompletedTask);
+            => Task.CompletedTask;
 
         public ProjectionOptions()
         {
             Name = string.Empty;
-            Filters = Array.Empty<StreamFilter>();
+            Filters = Array.Empty<ProjectionFilter>();
             ExceptionHandler = EmptyExceptionHandler;
         }
 
         public string Name { get; set; }
 
-        public IReadOnlyCollection<StreamFilter> Filters { get; set; }
+        public IReadOnlyCollection<ProjectionFilter> Filters { get; set; }
 
         public ProcessExceptionHandler ExceptionHandler { get; set; }
     }

--- a/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionProcessor.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Projections/ProjectionProcessor.cs
@@ -11,7 +11,7 @@ namespace Atc.Cosmos.EventStore.Cqrs.Projections
     internal class ProjectionProcessor<TProjection> : IProjectionProcessor<TProjection>
         where TProjection : IProjection
     {
-        private readonly IReadOnlyCollection<StreamFilter> filters;
+        private readonly IReadOnlyCollection<ProjectionFilter> filters;
         private readonly IProjectionFactory projectionFactory;
         private readonly IProjectionDiagnostics diagnostics;
         private readonly IProjectionMetadata projectionMetadata;

--- a/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
+++ b/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.28.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosSubscriptionFactory.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosSubscriptionFactory.cs
@@ -22,13 +22,15 @@ namespace Atc.Cosmos.EventStore.Cosmos
         public IStreamSubscription Create(
             ConsumerGroup consumerGroup,
             SubscriptionStartOptions startOptions,
-            ProcessEventsHandler eventsHandler)
+            ProcessEventsHandler eventsHandler,
+            ProcessExceptionHandler exceptionHandler)
         {
             var builder = containerProvider
                 .GetStreamContainer()
                 .GetChangeFeedProcessorBuilder<EventDocument>(
                     GetProcessorName(consumerGroup),
                     (c, ct) => eventsHandler(c.Where(ExcludeMetaDataChanges).ToArray(), ct))
+                .WithErrorNotification((lt, ex) => exceptionHandler(lt, ex))
                 .WithLeaseContainer(containerProvider.GetSubscriptionContainer())
                 .WithMaxItems(100)
                 .WithPollInterval(TimeSpan.FromMilliseconds(1000));

--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosSubscriptionProcessor.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosSubscriptionProcessor.cs
@@ -32,11 +32,16 @@ namespace Atc.Cosmos.EventStore.Cosmos
 
         public async Task StopAsync()
         {
-            await processor
-                .StopAsync()
-                .ConfigureAwait(false);
+            if (activity is { })
+            {
+                await processor
+                    .StopAsync()
+                    .ConfigureAwait(false);
 
-            activity?.SubscriptionStopped();
+                activity.SubscriptionStopped();
+            }
+
+            activity = null;
         }
     }
 }

--- a/src/Atc.Cosmos.EventStore/EventStoreClient.cs
+++ b/src/Atc.Cosmos.EventStore/EventStoreClient.cs
@@ -78,12 +78,14 @@ namespace Atc.Cosmos.EventStore
         public IStreamSubscription SubscribeToStreams(
             ConsumerGroup consumerGroup,
             SubscriptionStartOptions startOptions,
-            ProcessEventsHandler eventsHandler)
+            ProcessEventsHandler eventsHandler,
+            ProcessExceptionHandler exceptionHandler)
             => subscriptionFactory
                 .Create(
                     Arguments.EnsureNotNull(consumerGroup, nameof(consumerGroup)),
                     startOptions,
-                    Arguments.EnsureNotNull(eventsHandler, nameof(eventsHandler)));
+                    Arguments.EnsureNotNull(eventsHandler, nameof(eventsHandler)),
+                    Arguments.EnsureNotNull(exceptionHandler, nameof(exceptionHandler)));
 
         public Task<StreamResponse> WriteToStreamAsync(
             StreamId streamId,

--- a/src/Atc.Cosmos.EventStore/IEventStoreClient.cs
+++ b/src/Atc.Cosmos.EventStore/IEventStoreClient.cs
@@ -59,11 +59,13 @@ namespace Atc.Cosmos.EventStore
         /// <param name="consumerGroup">The name the subscription is persisted with.</param>
         /// <param name="startOptions">Start options for subscription.</param>
         /// <param name="eventsHandler">Delegate called when events arrives.</param>
+        /// <param name="exceptionHandler">Delegate called when an exception occurred.</param>
         /// <returns>Event subscription.</returns>
         IStreamSubscription SubscribeToStreams(
             ConsumerGroup consumerGroup,
             SubscriptionStartOptions startOptions,
-            ProcessEventsHandler eventsHandler);
+            ProcessEventsHandler eventsHandler,
+            ProcessExceptionHandler exceptionHandler);
 
         /// <summary>
         /// Delete subscription.

--- a/src/Atc.Cosmos.EventStore/InMemory/InMemoryStore.cs
+++ b/src/Atc.Cosmos.EventStore/InMemory/InMemoryStore.cs
@@ -36,7 +36,8 @@ namespace Atc.Cosmos.EventStore.InMemory
         IStreamSubscription IStreamSubscriptionFactory.Create(
             ConsumerGroup consumerGroup,
             SubscriptionStartOptions startOptions,
-            ProcessEventsHandler eventsHandler)
+            ProcessEventsHandler eventsHandler,
+            ProcessExceptionHandler exceptionHandler)
             => throw new NotImplementedException();
 
         Task IStreamSubscriptionRemover.DeleteAsync(

--- a/src/Atc.Cosmos.EventStore/ProcessExceptionHandler.cs
+++ b/src/Atc.Cosmos.EventStore/ProcessExceptionHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Atc.Cosmos.EventStore
@@ -7,10 +6,10 @@ namespace Atc.Cosmos.EventStore
     /// <summary>
     /// Delegate for handling exceptions in a subscription.
     /// </summary>
+    /// <param name="leaseToken">A unique identifier for the lease.</param>
     /// <param name="exception">The exception received.</param>
-    /// <param name="cancellationToken"><seealso cref="CancellationToken"/> representing request cancellation.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public delegate ValueTask ProcessExceptionHandler(
-        Exception exception,
-        CancellationToken cancellationToken);
+    public delegate Task ProcessExceptionHandler(
+        string leaseToken,
+        Exception exception);
 }

--- a/src/Atc.Cosmos.EventStore/Streams/IStreamSubscriptionFactory.cs
+++ b/src/Atc.Cosmos.EventStore/Streams/IStreamSubscriptionFactory.cs
@@ -5,6 +5,7 @@ namespace Atc.Cosmos.EventStore.Streams
         IStreamSubscription Create(
             ConsumerGroup consumerGroup,
             SubscriptionStartOptions startOptions,
-            ProcessEventsHandler eventsHandler);
+            ProcessEventsHandler eventsHandler,
+            ProcessExceptionHandler exceptionHandler);
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -55,7 +55,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.244" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.107" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.45" />
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Atc.Test" Version="1.0.64" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/DependencyInjection/Internal/ProjectionBuilderTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/DependencyInjection/Internal/ProjectionBuilderTests.cs
@@ -1,0 +1,56 @@
+using System;
+using Atc.Cosmos.EventStore.Cqrs.DependencyInjection.Internal;
+using Atc.Cosmos.EventStore.Cqrs.Projections;
+using Atc.Cosmos.EventStore.Cqrs.Tests.Mocks;
+using Atc.Test;
+using FluentAssertions;
+using Xunit;
+
+namespace Atc.Cosmos.EventStore.Cqrs.Tests.DependencyInjection.Internal
+{
+    public class ProjectionBuilderTests
+    {
+        [Theory, AutoNSubstituteData]
+        internal void Should_Set_Name(
+            string name,
+            ProjectionOptions options,
+            ProjectionBuilder sut)
+        {
+            sut.WithJobName(name);
+            sut.Build<TestProjection>(options);
+
+            options.Name.Should().Be(name);
+        }
+
+        [Theory, AutoNSubstituteData]
+        internal void ShouldThrow_When_Projection_IsMissing_ProjectionFilter(
+            ProjectionOptions options,
+            ProjectionBuilder sut)
+            => FluentActions
+                .Invoking(() => sut.Build<TestProjectionMissingFilterAttribute>(options))
+                .Should()
+                .ThrowExactly<ArgumentException>();
+
+        [Theory, AutoNSubstituteData]
+        internal void Should_Set_ExceptionHandler(
+            ProcessExceptionHandler handler,
+            ProjectionOptions options,
+            ProjectionBuilder sut)
+        {
+            sut.WithExceptionHandler(handler);
+            sut.Build<TestProjection>(options);
+
+            options.ExceptionHandler.Should().Be(handler);
+        }
+
+        [Theory, AutoNSubstituteData]
+        internal void ShouldHave_Default_ExceptionHandler(
+            ProjectionOptions options,
+            ProjectionBuilder sut)
+        {
+            sut.Build<TestProjection>(options);
+
+            options.ExceptionHandler.Should().NotBeNull();
+        }
+    }
+}

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjection.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjection.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Atc.Cosmos.EventStore.Cqrs.Tests.Mocks
+{
+    [ProjectionFilter("**")]
+    internal class TestProjection : IProjection
+    {
+        public Task CompleteAsync(
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<ProjectionAction> FailedAsync(
+            Exception exception,
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task InitializeAsync(
+            EventStreamId id,
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+}

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjectionMissingFilterAttribute.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjectionMissingFilterAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Atc.Cosmos.EventStore.Cqrs.Tests.Mocks
+{
+    internal class TestProjectionMissingFilterAttribute : IProjection
+    {
+        public Task CompleteAsync(
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task<ProjectionAction> FailedAsync(
+            Exception exception,
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+
+        public Task InitializeAsync(
+            EventStreamId id,
+            CancellationToken cancellationToken)
+            => throw new NotImplementedException();
+    }
+}

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Projections/ProjectionFilterTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Projections/ProjectionFilterTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Atc.Cosmos.EventStore.Cqrs.Tests.Projections
 {
-    public class StreamFilterTests
+    public class ProjectionFilterTests
     {
         [Theory]
         [InlineAutoNSubstituteData("*", "type.1", false)]
@@ -36,7 +36,7 @@ namespace Atc.Cosmos.EventStore.Cqrs.Tests.Projections
             string filter,
             string streamId,
             bool pass)
-            => new StreamFilter(filter)
+            => new ProjectionFilter(filter)
                 .Evaluate(streamId)
                 .Should()
                 .Be(pass);
@@ -70,7 +70,7 @@ namespace Atc.Cosmos.EventStore.Cqrs.Tests.Projections
             string filter,
             string streamId,
             bool pass)
-            => new StreamFilter(filter)
+            => new ProjectionFilter(filter)
                 .Evaluate(streamId)
                 .Should()
                 .Be(pass);

--- a/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
+++ b/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.45" />
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Atc.Test" Version="1.0.64" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.45" />
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Atc.Test" Version="1.0.64" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,7 +12,7 @@
 
   <ItemGroup Label="Test Analyzers">
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15" PrivateAssets="All" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR improves insights and exception handling for subscriptions and projections.

**BREAKING** - `IProjection` have a new method for handling exception doing a projection.
``` C#
Task<ProjectionAction> FailedAsync(
            Exception exception,
            CancellationToken cancellationToken);
```
You can control how the projection job will behave after receiving an exception. You can choose to `Continue` or `Stop`.
> Stop will stop the entire projection job so no more processing will occur.

Additionally you can configure a `ProcessExceptionHandler` on any projection job that will forward any subscription and Cosmos change feed internal exceptions.

``` C#
c.AddProjectionJob<MyProjection>("my-projection", c => c.WithExceptionHandler(
                (l, e) =>
                {
                    Console.WriteLine(e.ToString());

                    return Task.CompletedTask;
                }));
```

If a projection is missing a `ProjectionFilter` an `ArgumentException` will be thrown before job can be started.
