### PR TITLE
Fix concurrency issue on initial event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added custom event data converters to be configured using `EventStoreOptions`. This will enable scenarioes such as converting from one version of an event to another.
 - Unknown or invalid events can now be observed through the `IConsumeEvent<T>` and `IConsumeEventAsync<T>` but using well known types `FaultedEvent` and `UnknownEvent`.
 - Introduced new interfaces `IConsumeAnyEvent` and `IConsumeAnyEventAsync` for consuming any event without specifying it type.
+- Fixed raise condition when 2 command processors tries to add the first event to the same stream concurrently.
 
 ### Removed
 - Setting `ConfigurationString` when configuring event store options.
+- `EventId` has been removed from `Metadata`.
 
 ## [1.6.8] - 2022-07-06
 

--- a/src/Atc.Cosmos.EventStore.Cqrs/EventMetadata.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/EventMetadata.cs
@@ -1,7 +1,6 @@
 namespace Atc.Cosmos.EventStore.Cqrs;
 
 public record EventMetadata(
-    string EventId,
     EventStreamId StreamId,
     DateTimeOffset Timestamp,
     long Version,

--- a/src/Atc.Cosmos.EventStore.Cqrs/Internal/ConsumeEventMetadata.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Internal/ConsumeEventMetadata.cs
@@ -49,7 +49,6 @@ public abstract class ConsumeEventMetadata
         }
 
         var metadata = new EventMetadata(
-            evt.Metadata.EventId,
             EventStreamId.FromStreamId(evt.Metadata.StreamId),
             evt.Metadata.Timestamp,
             (long)evt.Metadata.Version,

--- a/src/Atc.Cosmos.EventStore.Cqrs/Testing/CommandHandlerTester.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Testing/CommandHandlerTester.cs
@@ -110,7 +110,6 @@ internal class CommandHandlerTester<TCommand> :
                         {
                             CausationId = Guid.NewGuid().ToString(),
                             CorrelationId = Guid.NewGuid().ToString(),
-                            EventId = Guid.NewGuid().ToString(),
                             Name = "test",
                             Version = version++,
                             Timestamp = DateTimeOffset.UtcNow,

--- a/src/Atc.Cosmos.EventStore/Cosmos/GuidEventIdProvider.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/GuidEventIdProvider.cs
@@ -1,9 +1,0 @@
-using Atc.Cosmos.EventStore.Events;
-
-namespace Atc.Cosmos.EventStore.Cosmos;
-
-internal class GuidEventIdProvider : IEventIdProvider
-{
-    public string CreateUniqueId(IStreamMetadata metadata)
-        => Guid.NewGuid().ToString();
-}

--- a/src/Atc.Cosmos.EventStore/DependencyInjection/EventStoreOptionsBuilder.cs
+++ b/src/Atc.Cosmos.EventStore/DependencyInjection/EventStoreOptionsBuilder.cs
@@ -52,14 +52,6 @@ public sealed class EventStoreOptionsBuilder
         return this;
     }
 
-    public EventStoreOptionsBuilder UseCustomEventIdProvider<T>()
-        where T : class, IEventIdProvider
-    {
-        Services.TryAddSingleton<IEventIdProvider, T>();
-
-        return this;
-    }
-
     public EventStoreOptionsBuilder UseEvents(Action<IEventCatalogBuilder> configure)
     {
         var builder = new EventCatalogBuilder();

--- a/src/Atc.Cosmos.EventStore/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Atc.Cosmos.EventStore/DependencyInjection/ServiceCollectionExtensions.cs
@@ -22,7 +22,6 @@ public static class ServiceCollectionExtensions
         configure?.Invoke(configureOptions);
 
         services.TryAddSingleton<IDateTimeProvider, UtcDateTimeProvider>();
-        services.TryAddSingleton<IEventIdProvider, GuidEventIdProvider>();
 
         services.TryAddSingleton<IStreamWriteValidator, StreamWriteValidator>();
         services.TryAddSingleton<IStreamReadValidator, StreamReadValidator>();

--- a/src/Atc.Cosmos.EventStore/Events/EventBatchProducer.cs
+++ b/src/Atc.Cosmos.EventStore/Events/EventBatchProducer.cs
@@ -5,16 +5,13 @@ namespace Atc.Cosmos.EventStore.Events;
 internal class EventBatchProducer : IEventBatchProducer
 {
     private readonly IDateTimeProvider dateTimeProvider;
-    private readonly IEventIdProvider eventIdProvider;
     private readonly IEventNameProvider nameProvider;
 
     public EventBatchProducer(
         IDateTimeProvider dateTimeProvider,
-        IEventIdProvider eventIdProvider,
         IEventNameProvider nameProvider)
     {
         this.dateTimeProvider = dateTimeProvider;
-        this.eventIdProvider = eventIdProvider;
         this.nameProvider = nameProvider;
     }
 
@@ -58,20 +55,18 @@ internal class EventBatchProducer : IEventBatchProducer
         string? causationId,
         DateTimeOffset timestamp)
     {
-        var eventId = eventIdProvider.CreateUniqueId(metadata);
         var streamId = metadata.StreamId.Value;
         var name = nameProvider.GetName(evt);
 
         return new EventDocument<object>
         {
-            Id = eventId,
+            Id = $"{version}",
             PartitionKey = streamId,
             Data = evt,
             Properties = new EventMetadata
             {
                 CausationId = causationId,
                 CorrelationId = correlationId,
-                EventId = eventId,
                 StreamId = streamId,
                 Version = version,
                 Timestamp = timestamp,

--- a/src/Atc.Cosmos.EventStore/Events/EventMetadata.cs
+++ b/src/Atc.Cosmos.EventStore/Events/EventMetadata.cs
@@ -7,8 +7,8 @@ namespace Atc.Cosmos.EventStore.Events;
 /// </summary>
 internal class EventMetadata : IEventMetadata
 {
-    [JsonIgnore]
-    public string EventId { get; set; } = string.Empty;
+    ////[JsonIgnore]
+    ////public string EventId { get; set; } = string.Empty;
 
     [JsonPropertyName(EventMetadataNames.EventName)]
     public string Name { get; set; } = string.Empty;

--- a/src/Atc.Cosmos.EventStore/Events/IEventIdProvider.cs
+++ b/src/Atc.Cosmos.EventStore/Events/IEventIdProvider.cs
@@ -1,6 +1,0 @@
-namespace Atc.Cosmos.EventStore.Events;
-
-public interface IEventIdProvider
-{
-    string CreateUniqueId(IStreamMetadata metadata);
-}

--- a/src/Atc.Cosmos.EventStore/IEventMetadata.cs
+++ b/src/Atc.Cosmos.EventStore/IEventMetadata.cs
@@ -6,11 +6,6 @@ namespace Atc.Cosmos.EventStore;
 public interface IEventMetadata
 {
     /// <summary>
-    /// Gets the unique id of the event.
-    /// </summary>
-    string EventId { get; }
-
-    /// <summary>
     /// Gets the name of the event.
     /// </summary>
     string Name { get; }

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeAnyEventAsyncMetadataTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeAnyEventAsyncMetadataTests.cs
@@ -45,7 +45,6 @@ public class ConsumeAnyEventAsyncMetadataTests :
                 .Should()
                 .BeEquivalentTo(
                     new EventMetadata(
-                        fixture.ConsumableEven.Metadata.EventId,
                         EventStreamId.FromStreamId(fixture.ConsumableEven.Metadata.StreamId),
                         fixture.ConsumableEven.Metadata.Timestamp,
                         (long)fixture.ConsumableEven.Metadata.Version,

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeAnyEventMetadataTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeAnyEventMetadataTests.cs
@@ -45,7 +45,6 @@ public class ConsumeAnyEventMetadataTests :
                 .Should()
                 .BeEquivalentTo(
                     new EventMetadata(
-                        fixture.ConsumableEven.Metadata.EventId,
                         EventStreamId.FromStreamId(fixture.ConsumableEven.Metadata.StreamId),
                         fixture.ConsumableEven.Metadata.Timestamp,
                         (long)fixture.ConsumableEven.Metadata.Version,

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeEventAsyncMetadataTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeEventAsyncMetadataTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Xunit;
 using static Atc.Cosmos.EventStore.Cqrs.Tests.Internal.ConsumeEventMetadataTestSpec;
 
@@ -52,7 +52,6 @@ public class ConsumeEventAsyncMetadataTests :
                 .Should()
                 .BeEquivalentTo(
                     new EventMetadata(
-                        fixture.ConsumableEven.Metadata.EventId,
                         EventStreamId.FromStreamId(fixture.ConsumableEven.Metadata.StreamId),
                         fixture.ConsumableEven.Metadata.Timestamp,
                         (long)fixture.ConsumableEven.Metadata.Version,

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeEventMetadataTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Internal/ConsumeEventMetadataTests.cs
@@ -52,7 +52,6 @@ public class ConsumeEventMetadataTests :
                 .Should()
                 .BeEquivalentTo(
                     new EventMetadata(
-                        fixture.ConsumableEven.Metadata.EventId,
                         EventStreamId.FromStreamId(fixture.ConsumableEven.Metadata.StreamId),
                         fixture.ConsumableEven.Metadata.Timestamp,
                         (long)fixture.ConsumableEven.Metadata.Version,

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjection.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjection.cs
@@ -1,7 +1,7 @@
 namespace Atc.Cosmos.EventStore.Cqrs.Tests.Mocks;
 
 [ProjectionFilter("**")]
-internal class TestProjection : IProjection
+internal sealed class TestProjection : IProjection
 {
     public Task CompleteAsync(
         CancellationToken cancellationToken)

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjectionMissingFilterAttribute.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Mocks/TestProjectionMissingFilterAttribute.cs
@@ -1,6 +1,6 @@
-﻿namespace Atc.Cosmos.EventStore.Cqrs.Tests.Mocks;
+namespace Atc.Cosmos.EventStore.Cqrs.Tests.Mocks;
 
-internal class TestProjectionMissingFilterAttribute : IProjection
+internal sealed class TestProjectionMissingFilterAttribute : IProjection
 {
     public Task CompleteAsync(
         CancellationToken cancellationToken)


### PR DESCRIPTION
This PR addresses an issue when two concurrent command processors is writing to an empty stream.

The etag of metadata document is used as the concurrency control mechanism to ensure only a single processor can write events at any given time. When a stream is empty the document is not existing hence the concurrency check is not possible.

To address this an additional concurrency control is introduced by using the documents `id` to ensure we don't insert events with the same `version`.

> As a consequence of the above changes the `EventId` is removed from metadata property.