### PR TITLE
Introduce command handler factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Pipeline for controlling event data convertion `IEventDataConverter`
 - Added custom event data converters to be configured using `EventStoreOptions`. This will enable scenarioes such as converting from one version of an event to another.
-- Unknown or invalid events can now be observed through the `IConsumeEvent<T>` and `IConsumeEventAsync<T>` but using well known types `FaultedEvent` and `UnknownEvent`.
+- Unknown or invalid events can now be observed through the `IConsumeEvent<T>` and `IConsumeEventAsync<T>` by using well known types `FaultedEvent` and `UnknownEvent`.
 - Introduced new interfaces `IConsumeAnyEvent` and `IConsumeAnyEventAsync` for consuming any event without specifying it type.
-- Fixed raise condition when 2 command processors tries to add the first event to the same stream concurrently.
+- Command processor is now registered as singleton, eliminating the need for using ICommandProcessorFactory.
+
+### Fixed
+- Raise condition when 2 command processors tries to add the first event to the same stream concurrently.
+- Rerunning command now create a new instance of the command processor to clear out any previous state it might contain.
 
 ### Removed
 - Setting `ConfigurationString` when configuring event store options.

--- a/src/Atc.Cosmos.EventStore.Cqrs/Commands/CommandHandlerFactory.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Commands/CommandHandlerFactory.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Atc.Cosmos.EventStore.Cqrs.Commands;
+
+internal class CommandHandlerFactory : ICommandHandlerFactory
+{
+    private readonly IServiceProvider provider;
+
+    public CommandHandlerFactory(
+        IServiceProvider provider)
+        => this.provider = provider;
+
+    public ICommandHandler<TCommand> Create<TCommand>()
+        where TCommand : ICommand
+        => provider.GetRequiredService<ICommandHandler<TCommand>>();
+}

--- a/src/Atc.Cosmos.EventStore.Cqrs/Commands/CommandProcessorFactory.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Commands/CommandProcessorFactory.cs
@@ -8,9 +8,7 @@ internal class CommandProcessorFactory : ICommandProcessorFactory
 
     public CommandProcessorFactory(
         IServiceProvider provider)
-    {
-        this.provider = provider;
-    }
+        => this.provider = provider;
 
     public ICommandProcessor<TCommand> Create<TCommand>()
         where TCommand : ICommand

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
@@ -20,8 +20,9 @@ public static class EventStoreOptionsBuilderExtensions
 
         builder.Services.AddSingleton(typeof(IStateProjector<>), typeof(StateProjector<>));
         builder.Services.AddSingleton(typeof(IStateWriter<>), typeof(StateWriter<>));
-        builder.Services.AddTransient(typeof(ICommandProcessor<>), typeof(CommandProcessor<>));
+        builder.Services.AddSingleton(typeof(ICommandProcessor<>), typeof(CommandProcessor<>));
         builder.Services.AddSingleton<ICommandProcessorFactory, CommandProcessorFactory>();
+        builder.Services.AddSingleton<ICommandHandlerFactory, CommandHandlerFactory>();
         builder.Services.AddSingleton<IProjectionOptionsFactory, ProjectionOptionsFactory>();
         builder.Services.AddSingleton<IProjectionFactory, ProjectionFactory>();
 

--- a/src/Atc.Cosmos.EventStore.Cqrs/ICommandHandlerFactory.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/ICommandHandlerFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Atc.Cosmos.EventStore.Cqrs;
+
+public interface ICommandHandlerFactory
+{
+    ICommandHandler<TCommand> Create<TCommand>()
+        where TCommand : ICommand;
+}


### PR DESCRIPTION
- Rerunning commands now creates a new instance of the handler before applying events.
- Command processor is now registered as singleton, eliminating the need for using ICommandProcessorFactory.