### PR TITLE
Add missing methods to IProjectionBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Add missing methods in `IProjectionBuilder` to enable configuration of projection subscription start options.
+
 ## [1.10.3] - 2023-09-05
 
 ### Added

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/IProjectionBuilder.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/IProjectionBuilder.cs
@@ -2,16 +2,50 @@ using Atc.Cosmos.EventStore;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
+/// <summary>
+/// Interface for projecting data from a source to a destination.
+/// </summary>
 public interface IProjectionBuilder
 {
     /// <summary>
     /// Filter on stream id for events projected.
     /// </summary>
     /// <param name="filter">Filter pattern.</param>
-    /// <returns>The builder.</returns>
+    /// <returns>Reference to this <see cref="IProjectionBuilder"/> instance.</returns>
     IProjectionBuilder WithFilter(string filter);
 
+    /// <summary>
+    /// Define a job name for the projection.
+    /// </summary>
+    /// <param name="name">Job name.</param>
+    /// <returns>Reference to this <see cref="IProjectionBuilder"/> instance.</returns>
     IProjectionBuilder WithJobName(string name);
 
+    /// <summary>
+    /// Set an exception handler for the projection process.
+    /// </summary>
+    /// <param name="handler">Handler for process exceptions.</param>
+    /// <returns>Reference to this <see cref="IProjectionBuilder"/> instance.</returns>
     IProjectionBuilder WithExceptionHandler(ProcessExceptionHandler handler);
+
+    /// <summary>
+    /// Indicate the point in time the projection should start from.
+    /// </summary>
+    /// <param name="startFrom">Projection start options.</param>
+    /// <returns>Reference to this <see cref="IProjectionBuilder"/> instance.</returns>
+    IProjectionBuilder WithProjectionStartsFrom(SubscriptionStartOptions startFrom);
+
+    /// <summary>
+    /// Set the polling interval for the projection.
+    /// </summary>
+    /// <param name="pollingInterval">Polling interval.</param>
+    /// <returns>Reference to this <see cref="IProjectionBuilder"/> instance.</returns>
+    IProjectionBuilder WithPollingInterval(TimeSpan pollingInterval);
+
+    /// <summary>
+    /// Set maximum number of items for the projection.
+    /// </summary>
+    /// <param name="maxItems">Maximum items count.</param>
+    /// <returns>Reference to this <see cref="IProjectionBuilder"/> instance.</returns>
+    IProjectionBuilder WithMaxItems(int maxItems);
 }

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/DependencyInjection/Internal/ProjectionBuilderTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/DependencyInjection/Internal/ProjectionBuilderTests.cs
@@ -3,6 +3,7 @@ using Atc.Cosmos.EventStore.Cqrs.Projections;
 using Atc.Cosmos.EventStore.Cqrs.Tests.Mocks;
 using Atc.Test;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Atc.Cosmos.EventStore.Cqrs.Tests.DependencyInjection.Internal;
@@ -15,7 +16,8 @@ public class ProjectionBuilderTests
         ProjectionOptions options,
         ProjectionBuilder sut)
     {
-        sut.WithJobName(name);
+        var abstraction = sut as IProjectionBuilder;
+        abstraction.WithJobName(name);
         sut.Build<TestProjection>(options);
 
         options.Name.Should().Be(name);
@@ -36,19 +38,56 @@ public class ProjectionBuilderTests
         ProjectionOptions options,
         ProjectionBuilder sut)
     {
-        sut.WithExceptionHandler(handler);
+        var abstraction = sut as IProjectionBuilder;
+        abstraction.WithExceptionHandler(handler);
         sut.Build<TestProjection>(options);
 
         options.ExceptionHandler.Should().Be(handler);
     }
 
     [Theory, AutoNSubstituteData]
-    internal void ShouldHave_Default_ExceptionHandler(
+    internal void Should_Have_Default_ExceptionHandler(
         ProjectionOptions options,
         ProjectionBuilder sut)
     {
         sut.Build<TestProjection>(options);
 
         options.ExceptionHandler.Should().NotBeNull();
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void Should_Set_StartFrom(
+        SubscriptionStartOptions startFrom,
+        ProjectionOptions options,
+        ProjectionBuilder sut)
+    {
+        var abstraction = sut as IProjectionBuilder;
+        abstraction.WithProjectionStartsFrom(startFrom);
+        sut.Build<TestProjection>(options);
+
+        options.StartsFrom.Should().Be(startFrom);
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void Should_Have_Default_StartFrom(
+        ProjectionOptions options,
+        ProjectionBuilder sut)
+    {
+        sut.Build<TestProjection>(options);
+
+        options.StartsFrom.Should().Be(SubscriptionStartOptions.FromBegining);
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void Should_Set_PollingInterval(
+        TimeSpan pollingInterval,
+        ProjectionOptions options,
+        ProjectionBuilder sut)
+    {
+        var abstraction = sut as IProjectionBuilder;
+        abstraction.WithPollingInterval(pollingInterval);
+        sut.Build<TestProjection>(options);
+
+        options.PollingInterval.Should().Be(pollingInterval);
     }
 }


### PR DESCRIPTION
The changes here add missing methods in `IProjectionBuilder` that were implemented in `ProjectionBuilder`

Without the changes here, the following code won't build:

```csharp
services.AddEventStore(builder =>
{
    builder.UseCosmosDb();
    builder.UseEvents(c => c.FromAssembly<MyEvent>());
    builder.UseCQRS(c =>
    {
        c.AddProjectionJob<MyProjection>(
            "super-projection-name",
            c => c.WithProjectionStartsFrom(
                SubscriptionStartOptions.FromBegining)); // setting the start time
    });
});
```