### PR TITLE
Cosmos SDK v3.46.0

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -28,10 +28,10 @@ jobs:
       - name: ⚙️ Setup GIT versioning
         uses: dotnet/nbgv@v0.4.0
 
-      - name: ⚙️ Setup dotnet 7.0.x
+      - name: ⚙️ Setup dotnet 9.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '9.0.x'
 
       - name: 🛠️ Building library in release mode
         run: dotnet pack -c Release -o ${GITHUB_WORKSPACE}/packages -p:ContinuousIntegrationBuild=true -p:publicrelease=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,10 @@ jobs:
         with:
           setAllVars: true
 
-      - name: ⚙️ Setup dotnet 7.0.x
+      - name: ⚙️ Setup dotnet 9.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '9.0.x'
 
       - name: 🛠️ Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@1.2.1

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           setAllVars: true
 
-      - name: ⚙️ Setup dotnet 7.0.x
+      - name: ⚙️ Setup dotnet 9.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '9.0.x'
 
       - name: 🛠️ Building libraries in release mode
         run: dotnet build -c release -p:ContinuousIntegrationBuild=true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Analyzer settings">
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <AnalysisMode>Default</AnalysisMode>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
+++ b/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.45.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />

--- a/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
+++ b/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
@@ -16,14 +16,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.34.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.45.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
+++ b/src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj
@@ -9,6 +9,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <DebugType>Portable</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <DisableNewtonsoftJsonCheck>true</DisableNewtonsoftJsonCheck>
+    <AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.75" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Atc.Test" Version="1.1.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
+++ b/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
+++ b/test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.70" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Atc.Test" Version="1.1.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
+++ b/test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.75" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Atc.Test" Version="1.1.4" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Atc.Cosmos.EventStore.Tests/Converters/EventDataConverterPipelineBuilderTests.cs
+++ b/test/Atc.Cosmos.EventStore.Tests/Converters/EventDataConverterPipelineBuilderTests.cs
@@ -14,7 +14,6 @@ public class EventDataConverterPipelineBuilderTests
     [Theory, AutoNSubstituteData]
     internal void Should_Call_All_Converters_InReverseOrder(
         IEventMetadata metadata,
-        JsonSerializerOptions options,
         FakeEventDataConverter[] converters,
         FakeEventDataConverter converter,
         EventDataConverterPipelineBuilder sut)
@@ -22,7 +21,7 @@ public class EventDataConverterPipelineBuilderTests
             .AddConverter(converter)
             .AddConverters(converters)
             .Build()
-            .Convert(metadata, doc.RootElement, options)
+            .Convert(metadata, doc.RootElement, new JsonSerializerOptions())
             .Should()
             .Be(string.Join(string.Empty, new[] { converter }.Concat(converters).Select(c => c.Val)));
 }

--- a/test/Atc.Cosmos.EventStore.Tests/Converters/FaultedEventDataConverterTests.cs
+++ b/test/Atc.Cosmos.EventStore.Tests/Converters/FaultedEventDataConverterTests.cs
@@ -14,14 +14,13 @@ public class FaultedEventDataConverterTests
     [Theory, AutoNSubstituteData]
     internal void Should_Return_Converted_Value(
         IEventMetadata metadata,
-        JsonSerializerOptions options,
         string expected,
         FaultedEventDataConverter sut)
         => sut
             .Convert(
                 metadata,
                 doc.RootElement,
-                options,
+                new JsonSerializerOptions(),
                 () => expected)
             .Should()
             .Be(expected);
@@ -29,14 +28,13 @@ public class FaultedEventDataConverterTests
     [Theory, AutoNSubstituteData]
     internal void Should_Return_FaultedEvent_When_Exception_IsThrown(
         IEventMetadata metadata,
-        JsonSerializerOptions options,
         KeyNotFoundException exception,
         FaultedEventDataConverter sut)
         => sut
             .Convert(
                 metadata,
                 doc.RootElement,
-                options,
+                new JsonSerializerOptions(),
                 () => throw exception)
             .Should()
             .BeEquivalentTo(

--- a/test/Atc.Cosmos.EventStore.Tests/Converters/NamedEventConverterTests.cs
+++ b/test/Atc.Cosmos.EventStore.Tests/Converters/NamedEventConverterTests.cs
@@ -18,7 +18,6 @@ public class NamedEventConverterTests
     internal void Should_Return_Value_FromNext_When_TypeName_IsNotFound(
         [Frozen] IEventTypeProvider typeProvider,
         IEventMetadata metadata,
-        JsonSerializerOptions options,
         string expected,
         NamedEventConverter sut)
     {
@@ -30,7 +29,7 @@ public class NamedEventConverterTests
             .Convert(
                 metadata,
                 doc.RootElement,
-                options,
+                new JsonSerializerOptions(),
                 () => expected)
             .Should()
             .Be(expected);

--- a/test/Atc.Cosmos.EventStore.Tests/Converters/UnknownEventDataConverterTests.cs
+++ b/test/Atc.Cosmos.EventStore.Tests/Converters/UnknownEventDataConverterTests.cs
@@ -14,14 +14,13 @@ public class UnknownEventDataConverterTests
     [Theory, AutoNSubstituteData]
     internal void Should_Return_Converted_Value_Id_NotNull(
         IEventMetadata metadata,
-        JsonSerializerOptions options,
         string expected,
         UnknownEventDataConverter sut)
         => sut
             .Convert(
                 metadata,
                 doc.RootElement,
-                options,
+                new JsonSerializerOptions(),
                 () => expected)
             .Should()
             .Be(expected);
@@ -29,13 +28,12 @@ public class UnknownEventDataConverterTests
     [Theory, AutoNSubstituteData]
     internal void Should_Return_UnknownEvent_When_Value_IsNot_Converted(
         IEventMetadata metadata,
-        JsonSerializerOptions options,
         UnknownEventDataConverter sut)
         => sut
             .Convert(
                 metadata,
                 doc.RootElement,
-                options,
+                new JsonSerializerOptions(),
                 () => null)
             .Should()
             .BeEquivalentTo(

--- a/test/Atc.Cosmos.EventStore.Tests/Streams/StreamInfoReaderTests.cs
+++ b/test/Atc.Cosmos.EventStore.Tests/Streams/StreamInfoReaderTests.cs
@@ -23,8 +23,7 @@ public class StreamInfoReaderTests
             .ReturnsForAnyArgs(expectedMetadata);
 
         var info = await sut
-            .ReadAsync(streamId, cancellationToken)
-            .ConfigureAwait(false);
+            .ReadAsync(streamId, cancellationToken);
 
         info
             .State
@@ -57,8 +56,7 @@ public class StreamInfoReaderTests
             .ReturnsForAnyArgs(expectedMetadata);
 
         await sut
-            .ReadAsync(streamId, cancellationToken)
-            .ConfigureAwait(false);
+            .ReadAsync(streamId, cancellationToken);
 
         _ = metadataReader
                 .Received(1)


### PR DESCRIPTION
This pull request includes several changes to project files and test files to update package versions and target frameworks, as well as minor code cleanups. The most important change here is updating the [Cosmos SDK to v3.46.0](https://github.com/Azure/azure-cosmos-dotnet-v3/releases/tag/3.46.0)

### Updates to package references and target frameworks:

* [`src/Atc.Cosmos.EventStore/Atc.Cosmos.EventStore.csproj`](diffhunk://#diff-862fd5f9a15d5ec8f33393a4bd37aec855a4264e7fd3dc70f475ebca5463966dR12-R27): Updated multiple package references to newer versions and added a new reference to `Newtonsoft.Json`.
* [`test/Atc.Cosmos.EventStore.Cqrs.Tests/Atc.Cosmos.EventStore.Cqrs.Tests.csproj`](diffhunk://#diff-d4d863aacfeb282802eae44278f2262bc4d8f990631f827a810d0d15ad8026bdL4-R17): Updated package references and changed the target framework from `net7.0` to `net9.0`.
* [`test/Atc.Cosmos.EventStore.IntegrationTests/Atc.Cosmos.EventStore.IntegrationTests.csproj`](diffhunk://#diff-cd46fe3466f2bc964cb9d88400eca61d187c53799a6cffacedcc8f2a5ce29486L4-R17): Updated package references and changed the target framework from `net7.0` to `net9.0`.
* [`test/Atc.Cosmos.EventStore.Tests/Atc.Cosmos.EventStore.Tests.csproj`](diffhunk://#diff-a70aed3f96ff9f0949bfc288d851da22e3f45d0dd024a44473e3b4d14535829cL4-R17): Updated package references and changed the target framework from `net7.0` to `net9.0`.

### Modifications to analyzer settings:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL30-R30): Changed the `AnalysisMode` from `AllEnabledByDefault` to `Default`.

### Code cleanup:

* [`test/Atc.Cosmos.EventStore.Tests/Streams/StreamInfoReaderTests.cs`](diffhunk://#diff-2b8c0b41980a0ab6350edd458bbe97aa6dc493b73597761e8eed8af47b2c4cf0L26-R26): Removed unnecessary `ConfigureAwait(false)` calls in two async methods. [[1]](diffhunk://#diff-2b8c0b41980a0ab6350edd458bbe97aa6dc493b73597761e8eed8af47b2c4cf0L26-R26) [[2]](diffhunk://#diff-2b8c0b41980a0ab6350edd458bbe97aa6dc493b73597761e8eed8af47b2c4cf0L60-R59)