### PR TITLE
Allow CommandHandlers to have scoped dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Changed `ICommandProcessorFactory`, `ICommandHandlerFactory` and `CommandProcessor<>` to be 
+ registered as transient rather than singleton. This allows `CommandHandler` implementations to use 
+ dependencies registered as scoped.
+
 ## [1.17.0] - 2025-03-21
 
 ### Fixed

--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
@@ -20,9 +20,9 @@ public static class EventStoreOptionsBuilderExtensions
 
         builder.Services.AddSingleton(typeof(IStateProjector<>), typeof(StateProjector<>));
         builder.Services.AddSingleton(typeof(IStateWriter<>), typeof(StateWriter<>));
-        builder.Services.AddSingleton(typeof(ICommandProcessor<>), typeof(CommandProcessor<>));
-        builder.Services.AddSingleton<ICommandProcessorFactory, CommandProcessorFactory>();
-        builder.Services.AddSingleton<ICommandHandlerFactory, CommandHandlerFactory>();
+        builder.Services.AddTransient(typeof(ICommandProcessor<>), typeof(CommandProcessor<>));
+        builder.Services.AddTransient<ICommandProcessorFactory, CommandProcessorFactory>();
+        builder.Services.AddTransient<ICommandHandlerFactory, CommandHandlerFactory>();
         builder.Services.AddSingleton<ICommandTelemetry, CommandTelemetry>();
 
         builder.Services.AddSingleton<IProjectionOptionsFactory, ProjectionOptionsFactory>();


### PR DESCRIPTION
Currently `ICommandProcessorFactory`, `ICommandHandlerFactory` and `CommandProcessor<>` are registered as singletons. This prevents CommandHandler implementations from using dependencies registered as scoped.

This PR changes the registrations to transient.