### PR TITLE
Bring back ProjectionFactory

### DIFF
--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
@@ -28,6 +28,7 @@ public static class EventStoreOptionsBuilderExtensions
         builder.Services.AddSingleton<IProjectionOptionsFactory, ProjectionOptionsFactory>();
 
         builder.Services.AddSingleton(typeof(ProjectionMetadata<>), typeof(ProjectionMetadata<>));
+        builder.Services.AddTransient<IProjectionFactory, DefaultProjectionFactory>();
 
         builder.Services.TryAddSingleton<IProjectionTelemetry, ProjectionTelemetry>();
 

--- a/src/Atc.Cosmos.EventStore.Cqrs/ProjectionFactory.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/ProjectionFactory.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Atc.Cosmos.EventStore.Cqrs;
+
+/// <summary>
+/// Responsible for creating <see cref="IProjection"/> instances.
+/// </summary>
+public interface IProjectionFactory
+{
+    /// <summary>
+    /// Creates a projection of type <typeparamref name="TProjection"/> for the event stream
+    /// identified by <paramref name="streamId"/>.
+    /// </summary>
+    /// <param name="streamId">ID of the stream being projected.</param>
+    /// <param name="cancellationToken">Cancellation.</param>
+    /// <typeparam name="TProjection">Type of projection to create.</typeparam>
+    /// <returns>The created projection.</returns>
+    public Task<IProjection> CreateAsync<TProjection>(EventStreamId streamId, CancellationToken cancellationToken)
+        where TProjection : IProjection;
+}
+
+/// <summary>
+/// The default projection factory which just creates projections by
+/// getting them from the DI-container.
+/// </summary>
+internal sealed class DefaultProjectionFactory : IProjectionFactory
+{
+    private readonly IServiceProvider serviceProvider;
+
+    public DefaultProjectionFactory(IServiceProvider serviceProvider)
+    {
+        this.serviceProvider = serviceProvider;
+    }
+
+    public Task<IProjection> CreateAsync<TProjection>(EventStreamId streamId, CancellationToken cancellationToken)
+        where TProjection : IProjection
+    {
+        return Task.FromResult<IProjection>(serviceProvider.GetRequiredService<TProjection>());
+    }
+}


### PR DESCRIPTION
Bring back `ProjectionFactory` but with a slightly different interface. This factory would allow consumers to make additional "initialization" of projections. One could argue that the `IProjection.InitializeAsync` method should be invoked by the `DefaultProjectionFactory` as that method is essentially an async constructor.

I have also changed `ProjectionProcessor` to use `IServiceScopeFactory` instead of `IServiceProvider` which, IMO, make it more clear that we are only creating scopes.