### PR TITLE
Use TryAdd when registering services + add EventStreamId ctor

### DIFF
--- a/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/DependencyInjection/EventStoreOptionsBuilderExtensions.cs
@@ -18,17 +18,17 @@ public static class EventStoreOptionsBuilderExtensions
 
         configure?.Invoke(cqrsBuilder);
 
-        builder.Services.AddSingleton(typeof(IStateProjector<>), typeof(StateProjector<>));
-        builder.Services.AddSingleton(typeof(IStateWriter<>), typeof(StateWriter<>));
-        builder.Services.AddTransient(typeof(ICommandProcessor<>), typeof(CommandProcessor<>));
-        builder.Services.AddTransient<ICommandProcessorFactory, CommandProcessorFactory>();
-        builder.Services.AddTransient<ICommandHandlerFactory, CommandHandlerFactory>();
-        builder.Services.AddSingleton<ICommandTelemetry, CommandTelemetry>();
+        builder.Services.TryAddSingleton(typeof(IStateProjector<>), typeof(StateProjector<>));
+        builder.Services.TryAddSingleton(typeof(IStateWriter<>), typeof(StateWriter<>));
+        builder.Services.TryAddTransient(typeof(ICommandProcessor<>), typeof(CommandProcessor<>));
+        builder.Services.TryAddTransient<ICommandProcessorFactory, CommandProcessorFactory>();
+        builder.Services.TryAddTransient<ICommandHandlerFactory, CommandHandlerFactory>();
+        builder.Services.TryAddSingleton<ICommandTelemetry, CommandTelemetry>();
 
-        builder.Services.AddSingleton<IProjectionOptionsFactory, ProjectionOptionsFactory>();
+        builder.Services.TryAddSingleton<IProjectionOptionsFactory, ProjectionOptionsFactory>();
 
-        builder.Services.AddSingleton(typeof(ProjectionMetadata<>), typeof(ProjectionMetadata<>));
-        builder.Services.AddTransient<IProjectionFactory, DefaultProjectionFactory>();
+        builder.Services.TryAddSingleton(typeof(ProjectionMetadata<>), typeof(ProjectionMetadata<>));
+        builder.Services.TryAddTransient<IProjectionFactory, DefaultProjectionFactory>();
 
         builder.Services.TryAddSingleton<IProjectionTelemetry, ProjectionTelemetry>();
 

--- a/src/Atc.Cosmos.EventStore.Cqrs/EventStreamId.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/EventStreamId.cs
@@ -31,7 +31,7 @@ public class EventStreamId
     public string Value { get; }
 
     public static implicit operator EventStreamId(StreamId id)
-        => FromStreamId(id.Value);
+        => FromStreamId(id);
 
     public static EventStreamId FromStreamId(StreamId id)
         => new(

--- a/src/Atc.Cosmos.EventStore.Cqrs/EventStreamId.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/EventStreamId.cs
@@ -16,6 +16,16 @@ public class EventStreamId
         Value = string.Join(PartSeperator, parts);
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventStreamId"/> class from an existing <see cref="EventStreamId"/>.
+    /// </summary>
+    /// <param name="existing">The existing <see cref="EventStreamId"/>.</param>
+    public EventStreamId(EventStreamId existing)
+    {
+        Parts = existing.Parts;
+        Value = existing.Value;
+    }
+
     public IReadOnlyList<string> Parts { get; }
 
     public string Value { get; }

--- a/test/Atc.Cosmos.EventStore.Cqrs.Tests/EventStreamIdTests.cs
+++ b/test/Atc.Cosmos.EventStore.Cqrs.Tests/EventStreamIdTests.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace Atc.Cosmos.EventStore.Cqrs.Commands.Tests;
+
+public class EventStreamIdTests
+{
+    [Fact]
+    public void Ctor_must_throw_when_no_arguments_are_provided()
+    {
+        Assert.Throws<ArgumentException>(() => new EventStreamId());
+    }
+
+    [Fact]
+    public void Value_property_must_return_joined_parts()
+    {
+        var id = new EventStreamId("foo", "bar");
+        id.Value.Should().Be("foo.bar");
+    }
+
+    [Fact]
+    public void Parts_property_must_return_parts()
+    {
+        var id = new EventStreamId("foo", "bar");
+        id.Parts.Should().BeEquivalentTo("foo", "bar");
+    }
+
+    [Fact]
+    public void EventStreamId_can_be_cloned_using_ctor()
+    {
+        var id = new EventStreamId("foo", "bar");
+        var clone = new EventStreamId(id);
+        id.Value.Should().Be(clone.Value);
+    }
+
+    [Fact]
+    public void EventStreamId_can_be_created_from_StreamId()
+    {
+        var streamId = new StreamId("foo.bar");
+        EventStreamId eventStreamId = streamId;
+        EventStreamId eventStreamId2 = EventStreamId.FromStreamId(streamId);
+        eventStreamId.Value.Should().Be("foo.bar");
+        eventStreamId2.Value.Should().Be("foo.bar");
+    }
+}


### PR DESCRIPTION
Currently the `UseCQRS()` method does not use TryAdd when registering services - like the `AddEventStore()` does. This means duplicate registrations when `UseCQRS()` are invoked multiple time.

Also add a ctor on `EventStreamId` that allow cheaper "cloning" of an existing `EventStreamId` - prevents `params string[] parts` allocation, and subsequent `string.Join()`.