### PR TITLE
Change command result to return event stream id from command instead of result

### DIFF
--- a/src/Atc.Cosmos.EventStore.Cqrs/Commands/CommandProcessor.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Commands/CommandProcessor.cs
@@ -85,7 +85,7 @@ internal class CommandProcessor<TCommand> : ICommandProcessor<TCommand>
             activity.Changed();
 
             return new CommandResult(
-                result.Id,
+                command.GetEventStreamId(),
                 result.Version,
                 ResultType.Changed,
                 context.ResponseObject);


### PR DESCRIPTION
Change command result for command processor to return event stream from command instead of result. This allows usages of derived instances of EventStreamId from the returned Command result.

E.g. i can outside the ExecuteAsync call use the returned stream id with polymorphism to do the following code:

```
if (eventStreamId is RfidCardId rfid)
{
    return rfid.Id;
}
```

given my class RfidCardId: 
```
public class RfidCardId : EventStreamId
{
    public string Id { get; }
    // rest of implementation
}
```