### PR TITLE
Refactor EventStore internals and modernize C# syntax

### DIFF
--- a/sample/GettingStarted.AppHost/GettingStarted.AppHost.csproj
+++ b/sample/GettingStarted.AppHost/GettingStarted.AppHost.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>386fc7b9-dd4c-4e84-b7cb-fa830e0a4015</UserSecretsId>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Atc.Cosmos.EventStore.Cqrs/CommandBase.cs
+++ b/src/Atc.Cosmos.EventStore.Cqrs/CommandBase.cs
@@ -2,9 +2,9 @@ namespace Atc.Cosmos.EventStore.Cqrs;
 
 public abstract record CommandBase<TStreamId>(
     TStreamId StreamId,
-    string? CommandId = default,
-    string? CorrelationId = default,
-    EventStreamVersion? RequiredVersion = default,
+    string? CommandId = null,
+    string? CorrelationId = null,
+    EventStreamVersion? RequiredVersion = null,
     OnConflict Behavior = OnConflict.Fail,
     int BehaviorCount = 3) : ICommand
     where TStreamId : EventStreamId

--- a/src/Atc.Cosmos.EventStore/Cosmos/CosmosSubscriptionFactory.cs
+++ b/src/Atc.Cosmos.EventStore/Cosmos/CosmosSubscriptionFactory.cs
@@ -22,7 +22,7 @@ internal class CosmosSubscriptionFactory : IStreamSubscriptionFactory
             .GetStreamContainer()
             .GetChangeFeedProcessorBuilder<EventDocument>(
                 GetProcessorName(consumerGroup),
-                (ctx, c, ct) => eventsHandler(c.Where(ExcludeMetaDataChanges).ToArray(), ct))
+                (ctx, c, ct) => eventsHandler([.. c.Where(ExcludeMetaDataChanges)], ct))
             .WithErrorNotification(async (lt, ex) =>
             {
                 telemetry.ProcessExceptionHandlerFailed(ex, consumerGroup);

--- a/src/Atc.Cosmos.EventStore/EventStoreClient.cs
+++ b/src/Atc.Cosmos.EventStore/EventStoreClient.cs
@@ -51,8 +51,8 @@ internal class EventStoreClient : IEventStoreClient
                 cancellationToken);
 
     public IAsyncEnumerable<IStreamIndex> QueryStreamsAsync(
-        string? filter = default,
-        DateTimeOffset? createdAfter = default,
+        string? filter = null,
+        DateTimeOffset? createdAfter = null,
         CancellationToken cancellationToken = default)
         => indexReader
             .ReadAsync(
@@ -62,8 +62,8 @@ internal class EventStoreClient : IEventStoreClient
 
     public IAsyncEnumerable<IEvent> ReadFromStreamAsync(
         StreamId streamId,
-        StreamVersion? fromVersion = default,
-        StreamReadFilter? filter = default,
+        StreamVersion? fromVersion = null,
+        StreamReadFilter? filter = null,
         CancellationToken cancellationToken = default)
         => streamReader
             .ReadAsync(
@@ -85,8 +85,8 @@ internal class EventStoreClient : IEventStoreClient
     public Task<StreamResponse> WriteToStreamAsync(
         StreamId streamId,
         IReadOnlyCollection<object> events,
-        StreamVersion? version = default,
-        StreamWriteOptions? options = default,
+        StreamVersion? version = null,
+        StreamWriteOptions? options = null,
         CancellationToken cancellationToken = default)
         => streamWriter
             .WriteAsync(

--- a/src/Atc.Cosmos.EventStore/IEventStoreClient.cs
+++ b/src/Atc.Cosmos.EventStore/IEventStoreClient.cs
@@ -20,8 +20,8 @@ public interface IEventStoreClient
     Task<StreamResponse> WriteToStreamAsync(
         StreamId streamId,
         IReadOnlyCollection<object> events,
-        StreamVersion? version = default,
-        StreamWriteOptions? options = default,
+        StreamVersion? version = null,
+        StreamWriteOptions? options = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -34,8 +34,8 @@ public interface IEventStoreClient
     /// <returns>List of events from stream.</returns>
     IAsyncEnumerable<IEvent> ReadFromStreamAsync(
         StreamId streamId,
-        StreamVersion? fromVersion = default,
-        StreamReadFilter? filter = default,
+        StreamVersion? fromVersion = null,
+        StreamReadFilter? filter = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -81,8 +81,8 @@ public interface IEventStoreClient
     /// <param name="cancellationToken">(Optional) <seealso cref="CancellationToken"/> representing request cancellation.</param>
     /// <returns>List of stream id found.</returns>
     IAsyncEnumerable<IStreamIndex> QueryStreamsAsync(
-        string? filter = default,
-        DateTimeOffset? createdAfter = default,
+        string? filter = null,
+        DateTimeOffset? createdAfter = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -102,7 +102,7 @@ public interface IEventStoreClient
         string name,
         StreamId streamId,
         StreamVersion version,
-        object? state = default,
+        object? state = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Atc.Cosmos.EventStore/IsExternalInit.cs
+++ b/src/Atc.Cosmos.EventStore/IsExternalInit.cs
@@ -1,7 +1,7 @@
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Atc.Cosmos.EventStore.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Atc.Cosmos.EventStore.Cqrs")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Atc.Cosmos.EventStore.Cqrs.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("DynamicProxyGenAssembly2")]
+[assembly: InternalsVisibleTo("Atc.Cosmos.EventStore.Tests")]
+[assembly: InternalsVisibleTo("Atc.Cosmos.EventStore.Cqrs")]
+[assembly: InternalsVisibleTo("Atc.Cosmos.EventStore.Cqrs.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace System.Runtime.CompilerServices;
 

--- a/src/Atc.Cosmos.EventStore/StreamClosedException.cs
+++ b/src/Atc.Cosmos.EventStore/StreamClosedException.cs
@@ -11,17 +11,13 @@ public sealed class StreamClosedException : EventStoreException
 
     public StreamClosedException(StreamId streamId)
         : base(MessageText)
-    {
-        StreamId = streamId;
-    }
+        => StreamId = streamId;
 
     public StreamClosedException(
         StreamId streamId,
         Exception innerException)
         : base(MessageText, innerException)
-    {
-        StreamId = streamId;
-    }
+        => StreamId = streamId;
 
     public StreamId StreamId { get; }
 }

--- a/src/Atc.Cosmos.EventStore/StreamId.cs
+++ b/src/Atc.Cosmos.EventStore/StreamId.cs
@@ -3,9 +3,7 @@ namespace Atc.Cosmos.EventStore;
 public struct StreamId : IEquatable<StreamId>
 {
     public StreamId(string streamId)
-    {
-        Value = streamId;
-    }
+        => Value = streamId;
 
     public string Value { get; }
 

--- a/src/Atc.Cosmos.EventStore/StreamVersion.cs
+++ b/src/Atc.Cosmos.EventStore/StreamVersion.cs
@@ -80,7 +80,7 @@ public struct StreamVersion : IComparable<StreamVersion>, IEquatable<StreamVersi
     ///   A value that indicates the relative order of the objects being compared. The
     ///   return value has these meanings: Value Meaning Less than zero This instance precedes
     ///   other in the sort order. Zero This instance occurs in the same position in the
-    ///   sort order as other. Greater than zero This instance follows other in the sort order.
+    ///   sort order as others. Greater than zero This instance follows other in the sort order.
     /// </returns>
     public int CompareTo(StreamVersion other)
         => Value.CompareTo(other.Value);


### PR DESCRIPTION
# Summary

- Modernize C# syntax across EventStore core classes
- Standardize null defaults for optional parameters
- Force a package version bump for updated NuGet icon
- Minor cleanup in sample AppHost configuration

# Changes

### :bug: Fixes
- Use null instead of default for optional parameters
- Apply change to CommandBase, EventStoreClient, IEventStoreClient

### :recycle: Refactoring
- Use expression-bodied constructors in StreamClosedException
- Use expression-bodied constructor in StreamId
- Use collection expression in change feed handler

### :wrench: Configuration
- Enable Aspire CLI bundle for GettingStarted.AppHost sample

### :memo: Documentation
- Fix grammar in StreamVersion CompareTo remarks

### :fire: Removal
- Remove redundant namespace qualification in InternalsVisibleTo attributes