### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "src/Atc.Cosmos.EventStore": "2.0.0",
-  "src/Atc.Cosmos.EventStore.Cqrs": "2.0.0"
+  "src/Atc.Cosmos.EventStore": "2.0.1",
+  "src/Atc.Cosmos.EventStore.Cqrs": "2.0.1"
 }

--- a/src/Atc.Cosmos.EventStore.Cqrs/CHANGELOG.md
+++ b/src/Atc.Cosmos.EventStore.Cqrs/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1](https://github.com/atc-net/atc-cosmos-eventstore/compare/Atc.Cosmos.EventStore.Cqrs@v2.0.0...Atc.Cosmos.EventStore.Cqrs@v2.0.1) (2026-08-25)
+
+
+### Bug fixes
+
+* use null instead of default for optional parameters ([e69e13f](https://github.com/atc-net/atc-cosmos-eventstore/commit/e69e13f8ca76b57be9a39ef5ee18da8ce8155f44))
+
 ## [2.0.0](https://github.com/atc-net/atc-cosmos-eventstore/compare/Atc.Cosmos.EventStore.Cqrs@v1.18.0...Atc.Cosmos.EventStore.Cqrs@v2.0.0) (2026-08-25)
 
 

--- a/src/Atc.Cosmos.EventStore.Cqrs/Directory.Build.props
+++ b/src/Atc.Cosmos.EventStore.Cqrs/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup Label="Versioning">
     <!-- The 'x-release-please-' comments are used to inform the release-please action that it should update the semver version here -->
     <!-- x-release-please-start-version -->
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <!-- x-release-please-end -->
     <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>

--- a/src/Atc.Cosmos.EventStore/CHANGELOG.md
+++ b/src/Atc.Cosmos.EventStore/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1](https://github.com/atc-net/atc-cosmos-eventstore/compare/Atc.Cosmos.EventStore@v2.0.0...Atc.Cosmos.EventStore@v2.0.1) (2026-08-25)
+
+
+### Bug fixes
+
+* use null instead of default for optional parameters ([e69e13f](https://github.com/atc-net/atc-cosmos-eventstore/commit/e69e13f8ca76b57be9a39ef5ee18da8ce8155f44))
+
 ## [2.0.0](https://github.com/atc-net/atc-cosmos-eventstore/compare/Atc.Cosmos.EventStore@v1.18.0...Atc.Cosmos.EventStore@v2.0.0) (2026-08-25)
 
 

--- a/src/Atc.Cosmos.EventStore/Directory.Build.props
+++ b/src/Atc.Cosmos.EventStore/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup Label="Versioning">
     <!-- The 'x-release-please-' comments are used to inform the release-please action that it should update the semver version here -->
     <!-- x-release-please-start-version -->
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <!-- x-release-please-end -->
     <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>


### PR DESCRIPTION
:robot: Preparing to release next version
---


<details><summary>Atc.Cosmos.EventStore: 2.0.1</summary>

## [2.0.1](https://github.com/atc-net/atc-cosmos-eventstore/compare/Atc.Cosmos.EventStore@v2.0.0...Atc.Cosmos.EventStore@v2.0.1) (2026-08-25)


### Bug fixes

* use null instead of default for optional parameters ([e69e13f](https://github.com/atc-net/atc-cosmos-eventstore/commit/e69e13f8ca76b57be9a39ef5ee18da8ce8155f44))
</details>

<details><summary>Atc.Cosmos.EventStore.Cqrs: 2.0.1</summary>

## [2.0.1](https://github.com/atc-net/atc-cosmos-eventstore/compare/Atc.Cosmos.EventStore.Cqrs@v2.0.0...Atc.Cosmos.EventStore.Cqrs@v2.0.1) (2026-08-25)


### Bug fixes

* use null instead of default for optional parameters ([e69e13f](https://github.com/atc-net/atc-cosmos-eventstore/commit/e69e13f8ca76b57be9a39ef5ee18da8ce8155f44))
</details>

---
This pull request was generated by release-please.